### PR TITLE
Fix .rubocop.yml namig conventions

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -14,7 +14,7 @@ AllCops:
 Documentation:
   Enabled: false
 
-Style/MultilineOperationIndentation:
+Layout/MultilineOperationIndentation:
   Enabled: false
 
 Style/CommandLiteral:
@@ -82,7 +82,7 @@ Style/PercentLiteralDelimiters:
      '%W': '[]'
      '%x': '()'
 
-Style/EmptyLinesAroundClassBody:
+Layout/EmptyLinesAroundClassBody:
   EnforcedStyle: empty_lines
 
 Metrics/LineLength:
@@ -106,7 +106,7 @@ Metrics/ClassLength:
 Metrics/ModuleLength:
   Max: 150
 
-Style/VariableNumber:
+Naming/VariableNumber:
   EnforcedStyle: 'snake_case'
 
 # ActiveAdmin, some config files (like rails environments or simple form) and the Rspec


### PR DESCRIPTION
It seems that latests versions of rubocop changed some rules namespaces, and this PR updates that rules.