### PR TITLE
Remove obsolete params

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -64,12 +64,6 @@ Style/RegexpLiteral:
 Style/SignalException:
   EnforcedStyle: semantic
 
-Style/IfUnlessModifier:
-  MaxLineLength: 60
-
-Style/WhileUntilModifier:
-  MaxLineLength: 60
-
 Style/PercentLiteralDelimiters:
    PreferredDelimiters:
      '%':  '()'


### PR DESCRIPTION
They were removed:

Error: obsolete parameter MaxLineLength (for Style/IfUnlessModifier) found in .rubocop-https---raw-githubusercontent-com-MarsBased-marstyle-master-ruby--rubocop-yml
`Style/IfUnlessModifier: MaxLineLength` has been removed. Use `Metrics/LineLength: Max` instead
obsolete parameter MaxLineLength (for Style/WhileUntilModifier) found in .rubocop-https---raw-githubusercontent-com-MarsBased-marstyle-master-ruby--rubocop-yml
`Style/WhileUntilModifier: MaxLineLength` has been removed. Use `Metrics/LineLength: Max` instead